### PR TITLE
Fix: Correct PHP 'i' to JS 'mm' time format conversion

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -946,6 +946,7 @@ class Format {
         'a' => 'tt',
         'HH' => 'H',
         'H' => 'HH',
+        'i' => 'mm',
         );
 
         return str_replace(array_keys($codes), array_values($codes), $format);


### PR DESCRIPTION
The Format::dtfmt_php2js() function was missing a translation for the PHP date format character 'i' (minutes with leading zeros) to its JavaScript equivalent 'mm'.

This caused issues when a PHP time format containing 'i' (often from global configuration) was used with DateTimePickerWidget. The 'i' would be passed literally to the JavaScript timepicker, resulting in the character 'i' appearing in the UI and potential errors in time parsing and selection.

This commit adds the 'i' => 'mm' mapping to ensure correct time format conversion, preventing the literal 'i' display and ensuring accurate time selection.